### PR TITLE
Output Settings Browse widget size fixed

### DIFF
--- a/lib/screens/settings/components/current_command.dart
+++ b/lib/screens/settings/components/current_command.dart
@@ -73,7 +73,7 @@ class CurrentCommandContainer extends StatelessWidget {
                     color: kBgLightColor,
                   ),
                   child: Padding(
-                    padding: const EdgeInsets.only(top: 10, left: 10),
+                    padding: const EdgeInsets.only(left: 10),
                     child: SelectableText(
                       'ccextractor --gui_mode_reports ${paramsList.reduce((value, element) => value + ' ' + element)} +[input files]',
                       // maxLines: 2,

--- a/lib/screens/settings/components/custom_path_button.dart
+++ b/lib/screens/settings/components/custom_path_button.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+
 import 'package:ccxgui/utils/constants.dart';
 import 'package:ccxgui/utils/responsive.dart';
 

--- a/lib/screens/settings/components/custom_path_button.dart
+++ b/lib/screens/settings/components/custom_path_button.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
-
 import 'package:ccxgui/utils/constants.dart';
 import 'package:ccxgui/utils/responsive.dart';
 
@@ -44,6 +42,7 @@ class _CustomGetFilePathButtonState extends State<CustomGetFilePathButton> {
   final ScrollController _scrollController = ScrollController();
   @override
   Widget build(BuildContext context) {
+    Size screensize = MediaQuery.of(context).size;
     _scrollController.hasClients
         ? _scrollController.animateTo(
             0.0,
@@ -59,7 +58,9 @@ class _CustomGetFilePathButtonState extends State<CustomGetFilePathButton> {
       trailing: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: Container(
-          width: Responsive.isDesktop(context) ? 300 : 100,
+          width: Responsive.isDesktop(context)
+              ? screensize.width * 0.25
+              : screensize.width * 0.145,
           child: Row(
             children: [
               Tooltip(
@@ -74,7 +75,9 @@ class _CustomGetFilePathButtonState extends State<CustomGetFilePathButton> {
                 width: 10,
               ),
               Container(
-                width: Responsive.isDesktop(context) ? 250 : 50,
+                width: Responsive.isDesktop(context)
+                    ? screensize.width * 0.205
+                    : screensize.width * 0.081,
                 height: 46,
                 color: kBgLightColor,
                 child: MaterialButton(


### PR DESCRIPTION
Fixes: #21 

Screenshot:
<img width="792" alt="Screenshot 2021-12-30 at 2 02 38 PM" src="https://user-images.githubusercontent.com/69353350/147735203-42806250-0cd3-44e8-88c0-e0d84d179e52.png">
