### PR TITLE
CommandWidget overflowing on small screens fixed

### DIFF
--- a/lib/screens/settings/components/current_command.dart
+++ b/lib/screens/settings/components/current_command.dart
@@ -66,9 +66,9 @@ class CurrentCommandContainer extends StatelessWidget {
                       ? MediaQuery.of(context).size.width - 270
                       : MediaQuery.of(context).size.width - 56,
                   height: Responsive.isDesktop(context)
-                      ? MediaQuery.of(context).size.height / 25
+                      ? MediaQuery.of(context).size.height / 20
                       : MediaQuery.of(context).size.height /
-                          5, // remove drawer width
+                          20, // remove drawer width
                   decoration: BoxDecoration(
                     color: kBgLightColor,
                   ),

--- a/lib/screens/settings/components/custom_path_button.dart
+++ b/lib/screens/settings/components/custom_path_button.dart
@@ -63,13 +63,14 @@ class _CustomGetFilePathButtonState extends State<CustomGetFilePathButton> {
           child: Row(
             children: [
               Tooltip(
-                  message: 'Clear field',
-                  child: IconButton(
-                    padding: EdgeInsets.zero,
-                    onPressed: widget.clearField,
-                    icon: Icon(Icons.delete_outline),
-                    color: Colors.red,
-                  )),
+                message: 'Clear field',
+                child: IconButton(
+                  padding: EdgeInsets.zero,
+                  onPressed: widget.clearField,
+                  icon: Icon(Icons.delete_outline),
+                  color: Colors.red,
+                ),
+              ),
               SizedBox(
                 width: 10,
               ),

--- a/lib/screens/settings/output_settings.dart
+++ b/lib/screens/settings/output_settings.dart
@@ -592,20 +592,21 @@ class OutputSettingsScreen extends StatelessWidget {
                     },
                   ),
                   CustomDropDown(
-                      title: 'Roll up',
-                      subtitle:
-                          'If having 3 or 4 lines annoys, use this to have 1,2,3 lines in roll-up captions',
-                      value: state.settingsModel.rollUp,
-                      items: rollUp,
-                      onChanged: (String newValue) {
-                        context.read<SettingsBloc>().add(
-                              SettingsUpdatedEvent(
-                                state.settingsModel.copyWith(
-                                  rollUp: newValue,
-                                ),
+                    title: 'Roll up',
+                    subtitle:
+                        'If having 3 or 4 lines annoys, use this to have 1,2,3 lines in roll-up captions',
+                    value: state.settingsModel.rollUp,
+                    items: rollUp,
+                    onChanged: (String newValue) {
+                      context.read<SettingsBloc>().add(
+                            SettingsUpdatedEvent(
+                              state.settingsModel.copyWith(
+                                rollUp: newValue,
                               ),
-                            );
-                      }),
+                            ),
+                          );
+                    },
+                  ),
                   CustomDropDown(
                     title: 'Stream Type',
                     subtitle:


### PR DESCRIPTION
## The issue of the command bar was fixed for larger screen size. On smaller screens, the issue persists.

Solves issue #17 
PR #8 solved the overflow issue on a bigger screen size but failed to address smaller screensize issues.
Solved the issue for all types of screen sizes and set a default sizing value for no future issues to occur!
### Previously

<img width="792" alt="Screenshot 2021-12-30 at 2 02 38 PM" src="https://user-images.githubusercontent.com/69353350/147735793-9696a4a0-bd6f-4e21-a72c-a10daa0a8823.png">

### Currently

<img width="792" alt="Screenshot 2021-12-30 at 2 13 21 PM" src="https://user-images.githubusercontent.com/69353350/147735795-6a36007d-cd8e-4fb8-b967-8b7b7ac06151.png">
