### PR TITLE
Changed sizing of drop down

### DIFF
--- a/lib/screens/settings/components/custom_dropdown.dart
+++ b/lib/screens/settings/components/custom_dropdown.dart
@@ -26,7 +26,7 @@ class CustomDropDown extends StatelessWidget {
       trailing: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: Container(
-          width: Responsive.isDesktop(context) ? 300 : 100,
+          width: Responsive.isDesktop(context) ? 300 : 125,
           color: kBgLightColor,
           child: DropdownButton<String>(
             underline: Container(),
@@ -36,10 +36,12 @@ class CustomDropDown extends StatelessWidget {
             items: items.map((String value) {
               return DropdownMenuItem(
                 value: value,
-                child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
-                  child: Text(value),
+                child: Center(
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(vertical: 12, horizontal: 5),
+                    child: Text(value),
+                  ),
                 ),
               );
             }).toList(),


### PR DESCRIPTION
fixes #28 
- Increased width and reduced padding of the drop-down menu.
- Centred items of the menu for a better look on bigger screen size.

**Screenshot:**

<img width="212" alt="Screenshot 2022-01-10 at 4 04 18 PM" src="https://user-images.githubusercontent.com/69353350/148752283-7d9fe6dc-1147-4480-bfdf-cdaa4e21dbe2.png">

