### PR TITLE
Fixes #33 : Fixed renderflex overflow in current command widget

### DIFF
--- a/lib/screens/settings/components/current_command.dart
+++ b/lib/screens/settings/components/current_command.dart
@@ -62,13 +62,14 @@ class CurrentCommandContainer extends StatelessWidget {
               SingleChildScrollView(
                 scrollDirection: Axis.vertical,
                 child: Container(
+                  alignment: Alignment.centerLeft,
                   width: Responsive.isDesktop(context)
                       ? MediaQuery.of(context).size.width - 270
                       : MediaQuery.of(context).size.width - 56,
                   height: Responsive.isDesktop(context)
-                      ? MediaQuery.of(context).size.height / 20
+                      ? MediaQuery.of(context).size.height / 25
                       : MediaQuery.of(context).size.height /
-                          20, // remove drawer width
+                          25, // remove drawer width
                   decoration: BoxDecoration(
                     color: kBgLightColor,
                   ),


### PR DESCRIPTION
fixes #33 
Fixed Renderflex overflow in current commad widget and align the command in centerLeft.

## Earlier
![ccex](https://user-images.githubusercontent.com/54404474/151365019-926fde9c-0315-47db-9c5b-9ef20525e750.png)


## Currently
![ccex1](https://user-images.githubusercontent.com/54404474/151365181-0d899808-51ad-4348-a69d-508aa5376218.png)

