### PR TITLE
Fixed updating of start stop button based on the actions on files in process tile

### DIFF
--- a/lib/screens/dashboard/components/process_tile.dart
+++ b/lib/screens/dashboard/components/process_tile.dart
@@ -87,7 +87,7 @@ class _ProcessTileState extends State<ProcessTile> {
                                     builder: (context) => AlertDialog(
                                           title: Text('Warning'),
                                           content: Text(
-                                            'Are you sure you want to remove the selected\nfiles and cancel any files that is running?',
+                                            'Are you sure you want to remove the selected\nfile and cancel any files that is running?',
                                           ),
                                           actions: [
                                             TextButton(

--- a/lib/screens/dashboard/components/process_tile.dart
+++ b/lib/screens/dashboard/components/process_tile.dart
@@ -119,8 +119,6 @@ class _ProcessTileState extends State<ProcessTile> {
                                             ),
                                           ],
                                         ));
-                                print("process_tile");
-                                print(state.progress);
                               },
                               icon: Icon(
                                 Icons.delete_outline,

--- a/lib/screens/dashboard/components/process_tile.dart
+++ b/lib/screens/dashboard/components/process_tile.dart
@@ -1,3 +1,4 @@
+import 'package:ccxgui/screens/dashboard/components/start_stop_button.dart';
 import 'package:flutter/material.dart';
 
 import 'package:file_selector/file_selector.dart';
@@ -5,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:ccxgui/bloc/dashboard_bloc/dashboard_bloc.dart';
 import 'package:ccxgui/bloc/process_bloc/process_bloc.dart';
+import 'package:ccxgui/screens/dashboard/components/start_stop_button.dart';
 
 class ProcessTile extends StatefulWidget {
   final XFile file;
@@ -80,17 +82,46 @@ class _ProcessTileState extends State<ProcessTile> {
                             ),
                             IconButton(
                               onPressed: () {
-                                context.read<DashboardBloc>().add(
-                                      FileRemoved(widget.file),
-                                    );
-                                try {
-                                  context.read<ProcessBloc>().add(
-                                        ProcessKill(widget.file),
-                                      );
-                                } catch (e) {
-                                  print(
-                                      'processing for this file never started');
-                                }
+                                showDialog(
+                                    context: context,
+                                    builder: (context) => AlertDialog(
+                                          title: Text('Warning'),
+                                          content: Text(
+                                            'Are you sure you want to remove the selected\nfiles and cancel any files that is running?',
+                                          ),
+                                          actions: [
+                                            TextButton(
+                                              onPressed: () =>
+                                                  Navigator.pop(context),
+                                              child: Text('No'),
+                                            ),
+                                            TextButton(
+                                              onPressed: () {
+                                                StartStopButton();
+                                                context
+                                                    .read<DashboardBloc>()
+                                                    .add(
+                                                      FileRemoved(widget.file),
+                                                    );
+                                                try {
+                                                  context
+                                                      .read<ProcessBloc>()
+                                                      .add(
+                                                        ProcessKill(
+                                                            widget.file),
+                                                      );
+                                                } catch (e) {
+                                                  print(
+                                                      'processing for this file never started');
+                                                }
+                                                Navigator.pop(context);
+                                              },
+                                              child: Text('Yes'),
+                                            ),
+                                          ],
+                                        ));
+                                print("process_tile");
+                                print(state.progress);
                               },
                               icon: Icon(
                                 Icons.delete_outline,

--- a/lib/screens/dashboard/components/process_tile.dart
+++ b/lib/screens/dashboard/components/process_tile.dart
@@ -1,4 +1,3 @@
-import 'package:ccxgui/screens/dashboard/components/start_stop_button.dart';
 import 'package:flutter/material.dart';
 
 import 'package:file_selector/file_selector.dart';

--- a/lib/screens/dashboard/components/start_stop_button.dart
+++ b/lib/screens/dashboard/components/start_stop_button.dart
@@ -8,7 +8,12 @@ import 'package:ccxgui/bloc/settings_bloc/settings_bloc.dart';
 import 'package:ccxgui/screens/dashboard/components/custom_snackbar.dart';
 
 //TODO: this file can probably be improved
-class StartStopButton extends StatelessWidget {
+class StartStopButton extends StatefulWidget {
+  @override
+  State<StartStopButton> createState() => _StartStopButtonState();
+}
+
+class _StartStopButtonState extends State<StartStopButton> {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<ProcessBloc, ProcessState>(
@@ -18,8 +23,15 @@ class StartStopButton extends StatelessWidget {
             return BlocBuilder<SettingsBloc, SettingsState>(
               builder: (context, settingsState) {
                 if (settingsState is CurrentSettingsState) {
+                  if (dashboardState.files.isEmpty && processState.started) {
+                    context.read<ProcessBloc>().add(
+                          StopAllProcess(),
+                        );
+                  }
                   return MaterialButton(
                     onPressed: () {
+                      print("start_stop");
+                      print(processState);
                       dashboardState.files.isEmpty
                           ? null
                           : processState.started
@@ -52,7 +64,10 @@ class StartStopButton extends StatelessWidget {
                       child: Row(
                         children: [
                           Text(
-                            processState.started ? 'Stop all' : 'Start all',
+                            dashboardState.files.isNotEmpty &&
+                                    processState.started
+                                ? 'Stop all'
+                                : 'Start all',
                             style: TextStyle(
                               fontSize: 20,
                             ),
@@ -60,7 +75,8 @@ class StartStopButton extends StatelessWidget {
                           SizedBox(
                             width: 5,
                           ),
-                          processState.started
+                          dashboardState.files.isNotEmpty &&
+                                  processState.started
                               ? Icon(Icons.stop,
                                   color: Colors.redAccent, size: 30)
                               : Icon(

--- a/lib/screens/dashboard/components/start_stop_button.dart
+++ b/lib/screens/dashboard/components/start_stop_button.dart
@@ -30,8 +30,6 @@ class _StartStopButtonState extends State<StartStopButton> {
                   }
                   return MaterialButton(
                     onPressed: () {
-                      print("start_stop");
-                      print(processState);
                       dashboardState.files.isEmpty
                           ? null
                           : processState.started


### PR DESCRIPTION
closes #47 
- this pr will be solving the issue #47 .
- fixed this bug by adding the feature to updated the status of start_stop_button from 'Stop All' to 'Start All' whenever we remove the files from process_tile during the process still going on.

https://user-images.githubusercontent.com/83648898/221266273-d3e7ae2b-f4e2-45e5-add2-e56c540345f1.mp4

