### PR TITLE
Improved 'Check for updates' button

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:ccxgui/utils/constants.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -17,6 +16,7 @@ import 'package:ccxgui/screens/settings/hardsubx_settings.dart';
 import 'package:ccxgui/screens/settings/input_settings.dart';
 import 'package:ccxgui/screens/settings/obscure_settings.dart';
 import 'package:ccxgui/screens/settings/output_settings.dart';
+import 'package:ccxgui/utils/constants.dart';
 
 class Home extends StatefulWidget {
   @override

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:ccxgui/utils/constants.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -79,6 +80,7 @@ class _HomeState extends State<Home> {
         hideTitleBar: true,
         drawerHeaderBuilder: (context) {
           return Column(
+            mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               DrawerHeader(
                 child: SvgPicture.asset(
@@ -88,53 +90,13 @@ class _HomeState extends State<Home> {
               ),
               BlocBuilder<ProcessBloc, ProcessState>(
                 builder: (context, state) {
-                  return Text(
-                    'Version: ' + state.version!.trim(),
-                    style: TextStyle(
-                        fontSize: 12,
-                        color: Theme.of(context)
-                            .bottomNavigationBarTheme
-                            .backgroundColor),
+                  return Column(
+                    children: [_checkForUpdates(state)],
                   );
                 },
               ),
             ],
           );
-        },
-        drawerFooterBuilder: (context) {
-          return Platform.isWindows
-              ? Padding(
-                  padding: const EdgeInsets.only(left: 20.0, bottom: 16),
-                  child: BlocBuilder<ProcessBloc, ProcessState>(
-                    builder: (context, processState) {
-                      return MaterialButton(
-                        hoverColor: Colors.transparent,
-                        onPressed: () {
-                          context
-                              .read<UpdaterBloc>()
-                              .add(CheckForUpdates(processState.version!));
-                        },
-                        child: Row(
-                          children: [
-                            Icon(
-                              Icons.update,
-                              color: Colors.white54,
-                            ),
-                            SizedBox(
-                              width: 20,
-                            ),
-                            Text(
-                              'Check for updates',
-                              style: TextStyle(
-                                  color: Colors.white60, fontSize: 14),
-                            ),
-                          ],
-                        ),
-                      );
-                    },
-                  ),
-                )
-              : Container();
         },
         currentIndex: _currentIndex,
         onTap: (val) {
@@ -182,6 +144,64 @@ class _HomeState extends State<Home> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _checkForUpdates(ProcessState state) {
+    if (!Platform.isWindows) return Container();
+
+    return BlocBuilder<ProcessBloc, ProcessState>(
+      builder: (context, processState) {
+        return InkWell(
+          borderRadius: BorderRadius.circular(25),
+          hoverColor: Colors.transparent,
+          onTap: () {
+            context
+                .read<UpdaterBloc>()
+                .add(CheckForUpdates(processState.version!));
+          },
+          child: Container(
+            margin: const EdgeInsets.all(10),
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(25),
+              color: kBgLightColor,
+            ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: IntrinsicHeight(
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.update,
+                      color: Colors.white54,
+                    ),
+                    VerticalDivider(),
+                    Expanded(
+                      child: FittedBox(
+                        child: Text(
+                          'Check for updates',
+                          style: TextStyle(color: Colors.white, fontSize: 15),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+                    VerticalDivider(),
+                    Text(
+                      'V${state.version!.trim()}',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white60,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -91,7 +91,7 @@ class _HomeState extends State<Home> {
               BlocBuilder<ProcessBloc, ProcessState>(
                 builder: (context, state) {
                   return Column(
-                    children: [_checkForUpdates(state)],
+                    children: [_CheckForUpdatesButton(state: state)],
                   );
                 },
               ),
@@ -146,8 +146,18 @@ class _HomeState extends State<Home> {
       ),
     );
   }
+}
 
-  Widget _checkForUpdates(ProcessState state) {
+class _CheckForUpdatesButton extends StatelessWidget {
+  const _CheckForUpdatesButton({
+    Key? key,
+    required this.state,
+  }) : super(key: key);
+
+  final ProcessState state;
+
+  @override
+  Widget build(BuildContext context) {
     if (!Platform.isWindows) return Container();
 
     return BlocBuilder<ProcessBloc, ProcessState>(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -88,13 +88,7 @@ class _HomeState extends State<Home> {
                   semanticsLabel: 'CCExtractor Logo',
                 ),
               ),
-              BlocBuilder<ProcessBloc, ProcessState>(
-                builder: (context, state) {
-                  return Column(
-                    children: [_CheckForUpdatesButton(state: state)],
-                  );
-                },
-              ),
+              _CheckForUpdatesButton()
             ],
           );
         },
@@ -151,24 +145,19 @@ class _HomeState extends State<Home> {
 class _CheckForUpdatesButton extends StatelessWidget {
   const _CheckForUpdatesButton({
     Key? key,
-    required this.state,
   }) : super(key: key);
-
-  final ProcessState state;
 
   @override
   Widget build(BuildContext context) {
     if (!Platform.isWindows) return Container();
 
     return BlocBuilder<ProcessBloc, ProcessState>(
-      builder: (context, processState) {
+      builder: (context, state) {
         return InkWell(
           borderRadius: BorderRadius.circular(25),
           hoverColor: Colors.transparent,
           onTap: () {
-            context
-                .read<UpdaterBloc>()
-                .add(CheckForUpdates(processState.version!));
+            context.read<UpdaterBloc>().add(CheckForUpdates(state.version!));
           },
           child: Container(
             margin: const EdgeInsets.all(10),


### PR DESCRIPTION
- Placed the "check for updates" button in the header instead of the footer to better incorporate the changes I made in 
  *https://github.com/Techno-Disaster/navigation_rail/pull/1

*fixes overflow in navigation rail by making it scrollable

| Before  | After |
|--------|--------|
| <img width="236" alt="Screenshot 2023-03-30 102838" src="https://user-images.githubusercontent.com/61899816/228733969-550da246-3375-453d-b5f2-697a6a77ee5c.png"> | <img width="226" alt="Screenshot 2023-03-30 102807" src="https://user-images.githubusercontent.com/61899816/228733963-b8d5655b-305e-4b70-80ae-bb34354503bc.png"> |
