### PR TITLE
Fix scrollbars in settings and dashboard UI

### DIFF
--- a/lib/screens/dashboard/dashboard.dart
+++ b/lib/screens/dashboard/dashboard.dart
@@ -231,7 +231,7 @@ class SelectedFilesContainer extends StatelessWidget {
                           ? Scrollbar(
                               child: ListView.builder(
                                 shrinkWrap: true,
-                                physics: ClampingScrollPhysics(),
+                                physics: AlwaysScrollableScrollPhysics(),
                                 itemCount:
                                     settingsState.settingsModel.splitMode &&
                                             state.files.length > 1
@@ -342,7 +342,7 @@ class LogsContainer extends StatelessWidget {
                   ? Scrollbar(
                       controller: _scrollController,
                       child: ListView.builder(
-                        shrinkWrap: true,
+                        shrinkWrap: false,
                         controller: _scrollController,
                         itemBuilder: (context, index) {
                           return Padding(

--- a/lib/screens/settings/basic_settings.dart
+++ b/lib/screens/settings/basic_settings.dart
@@ -50,9 +50,11 @@ class BasicSettingsScreen extends StatelessWidget {
             ),
             body: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: ListView(
+              child: Scrollbar(
                 controller: controller,
-                children: [
+                child: ListView(
+                  controller: controller,
+                  children: [
                   CustomTextField(
                     title: 'Output file name (press enter to save)',
                     subtitle:

--- a/lib/screens/settings/hardsubx_settings.dart
+++ b/lib/screens/settings/hardsubx_settings.dart
@@ -56,9 +56,11 @@ class HardSubxSettingsScreen extends StatelessWidget {
             ),
             body: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: ListView(
+              child: Scrollbar(
                 controller: controller,
-                children: [
+                child: ListView(
+                  controller: controller,
+                  children: [
                   CustomSwitchListTile(
                     title: 'HardSubx',
                     subtitle:

--- a/lib/screens/settings/input_settings.dart
+++ b/lib/screens/settings/input_settings.dart
@@ -46,9 +46,11 @@ class InputSettingsScreen extends StatelessWidget {
             ),
             body: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: ListView(
+              child: Scrollbar(
                 controller: controller,
-                children: [
+                child: ListView(
+                  controller: controller,
+                  children: [
                   CustomSwitchListTile(
                     title: 'Fix pts jumps',
                     subtitle:

--- a/lib/screens/settings/obscure_settings.dart
+++ b/lib/screens/settings/obscure_settings.dart
@@ -41,9 +41,11 @@ class ObscureSettingsScreen extends StatelessWidget {
             ),
             body: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: ListView(
+              child: Scrollbar(
                 controller: controller,
-                children: [
+                child: ListView(
+                  controller: controller,
+                  children: [
                   CustomSwitchListTile(
                     title: 'Panasonic DMR-ES15',
                     subtitle:

--- a/lib/screens/settings/output_settings.dart
+++ b/lib/screens/settings/output_settings.dart
@@ -72,9 +72,11 @@ class OutputSettingsScreen extends StatelessWidget {
             ),
             body: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: ListView(
+              child: Scrollbar(
                 controller: controller,
-                children: [
+                child: ListView(
+                  controller: controller,
+                  children: [
                   CustomSwitchListTile(
                     title: 'BOM',
                     subtitle:


### PR DESCRIPTION
- Add Scrollbar widgets to all settings screens (Basic, Input, Output, HardSubx, Obscure)
- Enable visual scrollbars on Windows that were previously missing
- Fix dashboard scrollbar click-drag functionality
- Ensure all scrollbars are properly interactive
PS : couldn't test visually since im on a mac 